### PR TITLE
Add Navigate component

### DIFF
--- a/packages/react/API.md
+++ b/packages/react/API.md
@@ -67,6 +67,28 @@ const App = () => {
 };
 ```
 
+## Navigate
+
+The `<Navigate>` element changes the location to the given route when rendered. It's a component wrapper around the [`router.navigate`](../router/API.md#navigate) function
+It accepts the same parameters as props.
+
+Example usage:
+
+```js
+<Navigate route="posts/new" />
+```
+
+```js
+<Navigate 
+  route="posts/edit"
+  params={{ id: 42 }}
+  queryParams={{ showSettings: true }}
+  hash="#settings"
+/>
+```
+
+Note this component's intended purpose is redirecting to default routes. See example [Switch on the route name](./Readme.md#switch-on-the-route-name)
+
 ## useLink
 
 A hook for getting link props for a given route.

--- a/packages/react/API.md
+++ b/packages/react/API.md
@@ -70,7 +70,7 @@ const App = () => {
 ## Navigate
 
 The `<Navigate>` element changes the location to the given route when rendered. It's a component wrapper around the [`router.navigate`](../router/API.md#navigate) function
-It accepts the same parameters as props.
+and accepts the same parameters as props.
 
 Example usage:
 

--- a/packages/react/Readme.md
+++ b/packages/react/Readme.md
@@ -75,13 +75,6 @@ const RootView = () => {
   const router = useRouter();
   const routeName = useRouteName();
 
-  useEffect(() => {
-    // redirect default route
-    if (routeName === "default") {
-      router.navigate({ route: "posts", replace: true });
-    }
-  });
-
   switch (routeName) {
     case "posts/new":
       return <PostNew />;
@@ -90,7 +83,7 @@ const RootView = () => {
     case "posts":
       return <PostList />;
     default:
-      return null;
+      return <Navigate route="posts" replace={true} />;
   }
 };
 ```

--- a/packages/react/src/Navigate.js
+++ b/packages/react/src/Navigate.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useRouter } from "./useRouter.js";
+
+export const Navigate = (props) => {
+  const { navigate } = useRouter();
+
+  useEffect(() => {
+    navigate(props);
+  }, [navigate, props]);
+
+  return null;
+};

--- a/packages/react/src/Navigate.js
+++ b/packages/react/src/Navigate.js
@@ -6,7 +6,8 @@ export const Navigate = (props) => {
 
   useEffect(() => {
     navigate(props);
-  }, [navigate, props]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return null;
 };

--- a/packages/react/src/Navigate.spec.js
+++ b/packages/react/src/Navigate.spec.js
@@ -1,0 +1,54 @@
+import React, { useMemo } from "react";
+import { createMemoryHistory } from "@nano-router/history";
+import expect, { mount, unmount } from "./expect.js";
+
+import { Routes, Route, Router, useRouter, Navigate } from "./index.js";
+
+const routes = new Routes(
+  new Route("posts", "/posts"),
+  new Route("new", "/new")
+);
+
+const Location = () => {
+  const { location } = useRouter();
+
+  return <div data-test-id="location">{location.pathname}</div>;
+};
+
+const App = () => {
+  const history = useMemo(
+    () => createMemoryHistory({ initialEntries: ["/posts"] }),
+    []
+  );
+
+  return (
+    <div>
+      <Router history={history} routes={routes}>
+        <Navigate route="new" />
+        <Location />
+      </Router>
+    </div>
+  );
+};
+
+describe("Navigate", () => {
+  let component;
+
+  beforeEach(() => {
+    component = mount(<App />);
+  });
+
+  afterEach(() => {
+    unmount(component);
+  });
+
+  it("navigates to new route", () => {
+    expect(
+      component,
+      "queried for test id",
+      "location",
+      "to have text",
+      "/new"
+    );
+  });
+});

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -1,5 +1,6 @@
 export { Router } from "./Router.js";
 export { Routes, Route, ExternalRoute } from "@nano-router/router";
+export { Navigate } from "./Navigate.js";
 export { useLink } from "./useLink.js";
 export { useLocation } from "./useLocation.js";
 export { useParams } from "./useParams.js";


### PR DESCRIPTION
The `<Navigate>` element changes the location to the given route when rendered. It's a component wrapper around the [`router.navigate`](../router/API.md#navigate) function
It accepts the same parameters as props.

Example usage:

```js
<Navigate route="posts/new" />
```

```js
<Navigate 
  route="posts/edit"
  params={{ id: 42 }}
  queryParams={{ showSettings: true }}
  hash="#settings"
/>
```

Note this component's intended purpose is redirecting to default routes. See example [Switch on the route name](./Readme.md#switch-on-the-route-name)
