### PR TITLE
Fix the package.json exports

### DIFF
--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -3,9 +3,11 @@
   "name": "@nano-router/history",
   "version": "3.1.0",
   "description": "Manage session history with JavaScript",
-  "main": "dist/bundle.cjs",
-  "module": "dist/bundle.mjs",
+  "main": "./dist/bundle.cjs",
+  "module": "./dist/bundle.mjs",
   "exports": {
+    "types": "./lib/index.d.ts",
+    "module": "./dist/bundle.mjs",
     "import": "./dist/bundle.mjs",
     "require": "./dist/bundle.cjs"
   },

--- a/packages/path/package.json
+++ b/packages/path/package.json
@@ -3,9 +3,11 @@
   "name": "@nano-router/path",
   "version": "3.1.0",
   "description": "Simple path patterns for matching and stringifying",
-  "main": "dist/bundle.cjs",
-  "module": "dist/bundle.mjs",
+  "main": "./dist/bundle.cjs",
+  "module": "./dist/bundle.mjs",
   "exports": {
+    "types": "./lib/index.d.ts",
+    "module": "./dist/bundle.mjs",
     "import": "./dist/bundle.mjs",
     "require": "./dist/bundle.cjs"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,9 +3,11 @@
   "name": "@nano-router/react",
   "version": "3.1.1",
   "description": "React integration for @nano-router/router",
-  "main": "dist/bundle.cjs",
-  "module": "dist/bundle.mjs",
+  "main": "./dist/bundle.cjs",
+  "module": "./dist/bundle.mjs",
   "exports": {
+    "types": "./lib/src/index.d.ts",
+    "module": "./dist/bundle.mjs",
     "import": "./dist/bundle.mjs",
     "require": "./dist/bundle.cjs"
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -16,9 +16,11 @@
     "type": "git",
     "url": "https://github.com/sunesimonsen/nano-router"
   },
-  "main": "dist/bundle.cjs",
-  "module": "dist/bundle.mjs",
+  "main": "./dist/bundle.cjs",
+  "module": "./dist/bundle.mjs",
   "exports": {
+    "types": "./lib/index.d.ts",
+    "module": "./dist/bundle.mjs",
     "import": "./dist/bundle.mjs",
     "require": "./dist/bundle.cjs"
   },

--- a/packages/routes/package.json
+++ b/packages/routes/package.json
@@ -4,8 +4,10 @@
   "version": "3.1.0",
   "description": "Objects to setup routes",
   "main": "./dist/bundle.cjs",
-  "module": "dist/bundle.mjs",
+  "module": "./dist/bundle.mjs",
   "exports": {
+    "types": "./lib/index.d.ts",
+    "module": "./dist/bundle.mjs",
     "import": "./dist/bundle.mjs",
     "require": "./dist/bundle.cjs"
   },

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -3,11 +3,13 @@
   "name": "@nano-router/url",
   "version": "3.1.0",
   "description": "Methods to create urls",
-  "main": "dist/url.cjs",
-  "module": "./dist/url.mjs",
+  "main": "./dist/bundle.cjs",
+  "module": "./dist/bundle.mjs",
   "exports": {
-    "import": "./dist/url.mjs",
-    "require": "./dist/url.cjs"
+    "types": "./lib/index.d.ts",
+    "module": "./dist/bundle.mjs",
+    "import": "./dist/bundle.mjs",
+    "require": "./dist/bundle.cjs"
   },
   "types": "./lib/index.d.ts",
   "scripts": {

--- a/packages/url/rollup.config.js
+++ b/packages/url/rollup.config.js
@@ -5,7 +5,7 @@ export default [
   {
     input: "lib/index.js",
     output: {
-      file: "dist/url.cjs",
+      file: "dist/bundle.cjs",
       format: "cjs",
     },
     external: ["querystring", "@nano-router/path"],
@@ -13,7 +13,7 @@ export default [
   {
     input: "lib/index.js",
     output: {
-      file: "dist/url.mjs",
+      file: "dist/bundle.mjs",
       format: "es",
     },
     plugins: [


### PR DESCRIPTION
When importing from TypeScript the compiler complains about the exports not including types, this change should fix the problem.